### PR TITLE
fix(syntax-interpreter) use attributeMap in bind method

### DIFF
--- a/src/syntax-interpreter.js
+++ b/src/syntax-interpreter.js
@@ -58,7 +58,7 @@ export class SyntaxInterpreter {
 
     instruction.attributes[info.attrName] = new BindingExpression(
         this.observerLocator,
-        info.attrName,
+        this.attributeMap[info.attrName] || info.attrName,
         this.parser.parse(info.attrValue),
         info.defaultBindingMode || this.determineDefaultBindingMode(element, info.attrName),
         resources.valueConverterLookupFunction    


### PR DESCRIPTION
Binding the 'for' attribute of a label element requires mapping to the 'htmlFor' property.

Fixes #1
