### PR TITLE
feat(templating-binding): new interpolation parser

### DIFF
--- a/src/interpolation-parser.js
+++ b/src/interpolation-parser.js
@@ -1,0 +1,95 @@
+export function parse(str, doYield) {
+  var index = 0;
+  var state = 0;
+  var match, curlies, start, lcurly, rcurly;
+
+  while (true) {
+    switch (state) {
+      case 0:
+        if (index === str.length)
+          return;
+
+        match = str.indexOf('${', index);
+        // if there is no match, doYield the rest of the string.
+        if (match === -1) {
+          doYield(
+            'text',
+            index,
+            str.length
+          );
+          return;
+        }
+
+        // check if escaped
+        if (match > 0 && str.charAt(match - 1) === '\\') {
+          // check if double escaped
+          if (match > 1 && str.charAt(match - 2) === '\\') {
+            // if double escaped, doYield up to and including slashes,
+            // then rerun from that point.
+            doYield(
+              'text',
+              index,
+              match - 2,
+              '\\'
+            );
+            index = match + 2;
+            curlies = 1;
+            start = index;
+            state = 1;
+            continue;
+          }
+
+          // if escaped, remove the slash, yiled the parts as text
+          doYield(
+            'text',
+            index,
+            match - 1,
+            '${'
+          );
+          index = match + 2;
+          continue;
+        }
+
+        // if it's not escaped
+        if (index < match) {
+          doYield(
+            'text',
+            index,
+            match
+          );
+        }
+        index = match + 2;
+        index = match + 2;
+        curlies = 1;
+        start = index;
+        state = 1;
+        continue;
+
+      case 1:
+        lcurly = str.indexOf('{', index);
+        rcurly = str.indexOf('}', index);
+
+        if (lcurly !== -1 && lcurly < rcurly) {
+          ++curlies;
+          index = lcurly + 1;
+          continue;
+        } else if (rcurly !== -1) {
+          index = rcurly + 1;
+          if (--curlies === 0) {
+            doYield(
+              'expr',
+              start,
+              rcurly
+            );
+            state = 0;
+            continue;
+          }
+
+          continue;
+        } else {
+          // alternatively, treat as string
+          throw new Error('Interpolation expression started at ' + (start - 2) + ' does not end');
+        }
+    }
+  }
+}

--- a/src/interpolation-parser.js
+++ b/src/interpolation-parser.js
@@ -9,7 +9,7 @@ function interpolationError(msg, index, string) {
 export function parse(str, doYield) {
   var index = 0;
   var state = 0;
-  var match, curlies, start, char, quote, slashes;
+  var match, curlies, start, char, quote;
 
   _parse: while (true) {
     switch (state) {
@@ -110,7 +110,6 @@ export function parse(str, doYield) {
 
       case 2:
         // Scan string inside interpolation
-        slashes = 0;
         while (true) {
           if (index === str.length) {
             throw interpolationError('String not closed.', start - 2, str);
@@ -119,22 +118,12 @@ export function parse(str, doYield) {
           char = str.charCodeAt(++index);
           switch (char) {
             case 92: // \
-              ++slashes;
+              ++index;
               continue;
 
             case quote:
-              // not escaped
-              if ((slashes % 2) === 0) {
-                state = 1;
-                continue _parse;
-              } else {
-                slashes = 0;
-              }
-              continue;
-
-            default:
-              slashes = 0;
-              continue;
+              state = 1;
+              continue _parse;
           }
         }
     }

--- a/src/syntax-interpreter.js
+++ b/src/syntax-interpreter.js
@@ -98,7 +98,7 @@ export class SyntaxInterpreter {
       );
 
     return instruction;
-  };
+  }
 
   options(resources, element, info, existingInstruction){
     var instruction = existingInstruction || {attrName:info.attrName, attributes:{}},

--- a/test/binding-language.spec.js
+++ b/test/binding-language.spec.js
@@ -2,7 +2,7 @@ import {InterpolationBindingExpression} from '../src/binding-language';
 
 describe('interpolation binding', () => {
   describe('interpolate', () => {
-    var observerLocator, targetProperty, accessScope, parts, myViewModel;
+    var observerLocator, targetProperty, accessScope, string, exprs, myViewModel;
 
     class ObserverLocator{
         getObserver(target, targetPropert){};
@@ -40,7 +40,8 @@ describe('interpolation binding', () => {
       targetProperty = new FooProperty();
       myViewModel = new MyViewModel
       accessScope = new AccessScope('fooCount');
-      parts = ['', accessScope];
+      string = '';
+      exprs = [{index: 0, expr: accessScope}];
 
       spyOn(observerLocator, 'getObserver').and.returnValue(targetProperty);
     });
@@ -51,7 +52,7 @@ describe('interpolation binding', () => {
 
       spyOn(accessScope, 'evaluate').and.returnValue(myViewModel.fooCount);
 
-      var interpolationBindingExpression = new InterpolationBindingExpression(observerLocator, targetProperty, parts);
+      var interpolationBindingExpression = new InterpolationBindingExpression(observerLocator, targetProperty, string, exprs);
       var interpolationBinding = interpolationBindingExpression.createBinding(createTarget());
       interpolationBinding.bind(myViewModel);
 
@@ -64,7 +65,7 @@ describe('interpolation binding', () => {
 
       spyOn(accessScope, 'evaluate').and.returnValue(myViewModel.fooCount);
 
-      var interpolationBindingExpression = new InterpolationBindingExpression(observerLocator, targetProperty, parts);
+      var interpolationBindingExpression = new InterpolationBindingExpression(observerLocator, targetProperty, string, exprs);
       var interpolationBinding = interpolationBindingExpression.createBinding(createTarget());
       interpolationBinding.bind(myViewModel);
 
@@ -77,7 +78,7 @@ describe('interpolation binding', () => {
 
       spyOn(accessScope, 'evaluate').and.returnValue(myViewModel.fooCount);
 
-      var interpolationBindingExpression = new InterpolationBindingExpression(observerLocator, targetProperty, parts);
+      var interpolationBindingExpression = new InterpolationBindingExpression(observerLocator, targetProperty, string, exprs);
       var interpolationBinding = interpolationBindingExpression.createBinding(createTarget());
       interpolationBinding.bind(myViewModel);
 
@@ -90,7 +91,7 @@ describe('interpolation binding', () => {
 
       spyOn(accessScope, 'evaluate').and.returnValue(myViewModel.fooCount);
 
-      var interpolationBindingExpression = new InterpolationBindingExpression(observerLocator, targetProperty, parts);
+      var interpolationBindingExpression = new InterpolationBindingExpression(observerLocator, targetProperty, string, exprs);
       var interpolationBinding = interpolationBindingExpression.createBinding(createTarget());
       interpolationBinding.bind(myViewModel);
 

--- a/test/binding-language.spec.js
+++ b/test/binding-language.spec.js
@@ -2,7 +2,7 @@ import {InterpolationBindingExpression} from '../src/binding-language';
 
 describe('interpolation binding', () => {
   describe('interpolate', () => {
-    var observerLocator, targetProperty, accessScope, string, exprs, myViewModel;
+    var observerLocator, targetProperty, accessScope, parts, myViewModel;
 
     class ObserverLocator{
         getObserver(target, targetPropert){};
@@ -40,8 +40,7 @@ describe('interpolation binding', () => {
       targetProperty = new FooProperty();
       myViewModel = new MyViewModel
       accessScope = new AccessScope('fooCount');
-      string = '';
-      exprs = [{index: 0, expr: accessScope}];
+      parts = [{type: 'expr', value: 'fooCount', expr: accessScope}];
 
       spyOn(observerLocator, 'getObserver').and.returnValue(targetProperty);
     });
@@ -52,7 +51,7 @@ describe('interpolation binding', () => {
 
       spyOn(accessScope, 'evaluate').and.returnValue(myViewModel.fooCount);
 
-      var interpolationBindingExpression = new InterpolationBindingExpression(observerLocator, targetProperty, string, exprs);
+      var interpolationBindingExpression = new InterpolationBindingExpression(observerLocator, targetProperty, parts);
       var interpolationBinding = interpolationBindingExpression.createBinding(createTarget());
       interpolationBinding.bind(myViewModel);
 
@@ -65,7 +64,7 @@ describe('interpolation binding', () => {
 
       spyOn(accessScope, 'evaluate').and.returnValue(myViewModel.fooCount);
 
-      var interpolationBindingExpression = new InterpolationBindingExpression(observerLocator, targetProperty, string, exprs);
+      var interpolationBindingExpression = new InterpolationBindingExpression(observerLocator, targetProperty, parts);
       var interpolationBinding = interpolationBindingExpression.createBinding(createTarget());
       interpolationBinding.bind(myViewModel);
 
@@ -78,7 +77,7 @@ describe('interpolation binding', () => {
 
       spyOn(accessScope, 'evaluate').and.returnValue(myViewModel.fooCount);
 
-      var interpolationBindingExpression = new InterpolationBindingExpression(observerLocator, targetProperty, string, exprs);
+      var interpolationBindingExpression = new InterpolationBindingExpression(observerLocator, targetProperty, parts);
       var interpolationBinding = interpolationBindingExpression.createBinding(createTarget());
       interpolationBinding.bind(myViewModel);
 
@@ -91,7 +90,7 @@ describe('interpolation binding', () => {
 
       spyOn(accessScope, 'evaluate').and.returnValue(myViewModel.fooCount);
 
-      var interpolationBindingExpression = new InterpolationBindingExpression(observerLocator, targetProperty, string, exprs);
+      var interpolationBindingExpression = new InterpolationBindingExpression(observerLocator, targetProperty, parts);
       var interpolationBinding = interpolationBindingExpression.createBinding(createTarget());
       interpolationBinding.bind(myViewModel);
 

--- a/test/interpolation-parser.spec.js
+++ b/test/interpolation-parser.spec.js
@@ -132,6 +132,10 @@ describe('interpolation-parser', () => {
     checkParse('${ foo | bar: "\\\\" }', [
       {type: 'expr', value: ' foo | bar: "\\\\" '}
     ]);
+
+    checkParse('${ foo | bar: "\\\\\\"" }', [
+      {type: 'expr', value: ' foo | bar: "\\\\\\"" '}
+    ]);
   });
 
   it('handles long input', () => {

--- a/test/interpolation-parser.spec.js
+++ b/test/interpolation-parser.spec.js
@@ -1,0 +1,136 @@
+import {parse} from '../src/interpolation-parser';
+
+function checkParse(text, expected) {
+  let results = [];
+  parse(text, (type, start, stop, extra) => {
+    results.push({type, value: text.substring(start, stop) + (extra || '')});
+  });
+  expect(results.reduce((seed, value) => {
+    if (value.type === 'text' && seed.length && seed[seed.length - 1].type === 'text') {
+      seed[seed.length - 1].value += value.value;
+      return seed;
+    }
+    seed.push(value);
+    return seed;
+  }, [])).toEqual(expected);
+}
+
+describe('interpolation-parser', () => {
+  it('parses strings as strings', () => {
+    checkParse('test', [
+      {type: 'text', value: 'test'}
+    ]);
+  });
+
+  it('parses expressions as expressions', () => {
+    checkParse('${test}', [
+      {type: 'expr', value: 'test'}
+    ]);
+  });
+
+  it('allows for objects in expressions', () => {
+    checkParse('${test | blah:{a:b}}', [
+      {type: 'expr', value: 'test | blah:{a:b}'}
+    ]);
+  });
+
+  it('allows for interpolations inside expressions', () => {
+    // this probably wouldn't work in browsers that doesn't
+    // support ES6 (i.e. all of them), but eventually it will
+    // and should be future proofed.
+    checkParse('${`${test}`}', [
+      {type: 'expr', value: '`${test}`'}
+    ]);
+  });
+
+  it('allows for multiple expressions', () => {
+    checkParse('${a}${b}', [
+      {type: 'expr', value: 'a'},
+      {type: 'expr', value: 'b'}
+    ]);
+  });
+
+  it('allows for a combination of text and expressions', () => {
+    checkParse('a${b}c${d}e', [
+      {type: 'text', value: 'a'},
+      {type: 'expr', value: 'b'},
+      {type: 'text', value: 'c'},
+      {type: 'expr', value: 'd'},
+      {type: 'text', value: 'e'}
+    ]);
+  });
+
+  it('allows escaping of the interpolation', () => {
+    // Note: in HTML this would be \${test}
+    checkParse('\\${test}', [
+      {type: 'text', value: '${test}'}
+    ]);
+  });
+
+  it('allows escaping the escape sequence', () => {
+    // Note: in HTML this would be \\${test}
+    checkParse('\\\\${test}', [
+      {type: 'text', value: '\\'},
+      {type: 'expr', value: 'test'}
+    ]);
+  });
+
+  it('throws on uncompleted interpolations', () => {
+    expect(() => {
+      parse('${test')
+    }).toThrowError(/^Interpolation expression started at \d+ does not end$/);
+  });
+
+  it('handles quotes', () => {
+    checkParse('${ foo | bar:"baz" }', [
+      {type: 'expr', value: ' foo | bar:"baz" '}
+    ]);
+
+    checkParse('${ foo | bar:\'baz\' }', [
+      {type: 'expr', value: ' foo | bar:\'baz\' '}
+    ]);
+
+    // would be \${ foo | bar:"baz" } in browser
+    checkParse('\\${ foo | bar:"baz" }', [
+      {type: 'text', value: '${ foo | bar:"baz" }'}
+    ]);
+
+    // would be \\${ foo | bar:"baz" } in browser
+    checkParse('\\\\${ foo | bar:"baz" }', [
+      {type: 'text', value: '\\'},
+      {type: 'expr', value: ' foo | bar:"baz" '}
+    ]);
+
+    checkParse('${ foo | bar: \'{}\' }', [
+      {type: 'expr', value: ' foo | bar: \'{}\' '}
+    ]);
+
+    checkParse('${ foo | bar: "{}" }', [
+      {type: 'expr', value: ' foo | bar: "{}" '}
+    ]);
+  });
+
+  it('handles long input', () => {
+    const baseString = 'foo ${bar} baz ${baffo | babel} bop ${batz}, \\${escaped} \\\\${not(escaped)}';
+    const baseResult = [
+      {type: 'text', value: 'foo '},
+      {type: 'expr', value: 'bar'},
+      {type: 'text', value: ' baz '},
+      {type: 'expr', value: 'baffo | babel'},
+      {type: 'text', value: ' bop '},
+      {type: 'expr', value: 'batz'},
+      {type: 'text', value: ', ${escaped} \\'},
+      {type: 'expr', value: 'not(escaped)'}
+    ];
+
+    checkParse(baseString, baseResult);
+    let longString = '';
+    let longResult = [];
+    for (let i = 0; i < 100; i++) {
+      longString += baseString;
+      longResult = longResult.concat(baseResult);
+    }
+
+    checkParse(longString, longResult);
+  });
+});

--- a/test/interpolation-parser.spec.js
+++ b/test/interpolation-parser.spec.js
@@ -78,7 +78,7 @@ describe('interpolation-parser', () => {
   it('throws on uncompleted interpolations', () => {
     expect(() => {
       parse('${test')
-    }).toThrowError(/^Interpolation expression started at \d+ does not end$/);
+    }).toThrowError(/^Interpolation not closed\./);
   });
 
   it('handles quotes', () => {
@@ -101,12 +101,36 @@ describe('interpolation-parser', () => {
       {type: 'expr', value: ' foo | bar:"baz" '}
     ]);
 
-    checkParse('${ foo | bar: \'{}\' }', [
-      {type: 'expr', value: ' foo | bar: \'{}\' '}
+    checkParse('${ foo | bar: \'{\' }', [
+      {type: 'expr', value: ' foo | bar: \'{\' '}
     ]);
 
-    checkParse('${ foo | bar: "{}" }', [
-      {type: 'expr', value: ' foo | bar: "{}" '}
+    checkParse('${ foo | bar: "{" }', [
+      {type: 'expr', value: ' foo | bar: "{" '}
+    ]);
+
+    checkParse('${ foo | bar: `{` }', [
+      {type: 'expr', value: ' foo | bar: `{` '}
+    ]);
+
+    checkParse('${ foo | bar: \'}\' }', [
+      {type: 'expr', value: ' foo | bar: \'}\' '}
+    ]);
+
+    checkParse('${ foo | bar: "}" }', [
+      {type: 'expr', value: ' foo | bar: "}" '}
+    ]);
+
+    checkParse('${ foo | bar: `}` }', [
+      {type: 'expr', value: ' foo | bar: `}` '}
+    ]);
+
+    checkParse('${ foo | bar: "\\"" }', [
+      {type: 'expr', value: ' foo | bar: "\\"" '}
+    ]);
+
+    checkParse('${ foo | bar: "\\\\" }', [
+      {type: 'expr', value: ' foo | bar: "\\\\" '}
     ]);
   });
 


### PR DESCRIPTION
New parser for string interpolation. Handles escaping,
and object literals (amongst other things) inside the
interpolation expressions.

Resolves #10 

~~I still need to do some perf work to make sure that the usage of the parser result (the `InterpolationBinding` is as efficient as possible).~~ This has now been done. Ready for review.

This uses the inlined dsl parsing algorithm from this perf: http://jsperf.com/aurelia-interpolation/2. It turned out that when you run on smaller input it's a lot faster than the non-inlined one. It handles escaping, and object literals, and a lot of other things. See extensive list of tests: https://github.com/Alxandr/templating-binding/blob/b7e394c8b12a0d5fab0a489789e57a8642705261/test/interpolation-parser.spec.js
