### PR TITLE
feat(SyntaxInterpreter) enable two-way binding of contenteditable elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     },
     "dependencies": {
       "aurelia-binding": "github:aurelia/binding@^0.3.7",
+      "aurelia-logging": "github:aurelia/logging@^0.2.5",
       "aurelia-templating": "github:aurelia/templating@^0.8.14"
     }
   },

--- a/src/binding-language.js
+++ b/src/binding-language.js
@@ -1,8 +1,10 @@
 import {BindingLanguage} from 'aurelia-templating';
 import {Parser, ObserverLocator, BindingExpression, NameExpression, ONE_WAY} from 'aurelia-binding';
 import {SyntaxInterpreter} from './syntax-interpreter';
+import * as LogManager from 'aurelia-logging';
 
-var info = {};
+var info = {},
+    logger = LogManager.getLogger('templating-binding');
 
 export class TemplatingBindingLanguage extends BindingLanguage {
   static inject() { return [Parser, ObserverLocator,SyntaxInterpreter]; }
@@ -16,6 +18,8 @@ export class TemplatingBindingLanguage extends BindingLanguage {
       'class':'className',
       'for':'htmlFor',
       'tabindex':'tabIndex',
+      'textcontent': 'textContent',
+      'innerhtml': 'innerHTML',
       // HTMLInputElement https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement
       'maxlength':'maxLength',
       'minlength':'minLength',
@@ -184,7 +188,7 @@ export class InterpolationBindingExpression {
 class InterpolationBinding {
   constructor(observerLocator, parts, target, targetProperty, mode, valueConverterLookupFunction){
     if (target.parentElement && target.parentElement.nodeName === 'TEXTAREA' && targetProperty === 'textContent') {
-      throw new Error('Interpolation binding cannot be used in the content of a textarea element.  Use "<textarea value.bind="expression"></textarea>"" instead');
+      throw new Error('Interpolation binding cannot be used in the content of a textarea element.  Use <textarea value.bind="expression"></textarea> instead.');
     }
     this.observerLocator = observerLocator;
     this.parts = parts;

--- a/src/syntax-interpreter.js
+++ b/src/syntax-interpreter.js
@@ -1,6 +1,6 @@
 import {
-  Parser, 
-  ObserverLocator, 
+  Parser,
+  ObserverLocator,
   EventManager,
   ListenerExpression,
   BindingExpression,
@@ -32,7 +32,7 @@ export class SyntaxInterpreter {
         command = info.command;
 
     var instruction = this.options(resources, element, info, existingInstruction);
-    
+
     instruction.alteredAttr = true;
     instruction.attrName = 'global-behavior';
     instruction.attributes.aureliaAttrName = attrName;
@@ -48,6 +48,8 @@ export class SyntaxInterpreter {
       return attrName === 'value' || attrName === 'checked' ? TWO_WAY : ONE_WAY;
     }else if(tagName == 'textarea' || tagName == 'select'){
       return attrName == 'value' ? TWO_WAY : ONE_WAY;
+    }else if(attrName === 'textcontent' || attrName === 'innerhtml'){
+      return element.contentEditable === 'true' ? TWO_WAY : ONE_WAY;
     }
 
     return ONE_WAY;
@@ -61,7 +63,7 @@ export class SyntaxInterpreter {
         this.attributeMap[info.attrName] || info.attrName,
         this.parser.parse(info.attrValue),
         info.defaultBindingMode || this.determineDefaultBindingMode(element, info.attrName),
-        resources.valueConverterLookupFunction    
+        resources.valueConverterLookupFunction
       );
 
     return instruction;
@@ -94,7 +96,7 @@ export class SyntaxInterpreter {
         this.observerLocator,
         info.attrName,
         this.parser.parse(info.attrValue),
-        resources.valueConverterLookupFunction    
+        resources.valueConverterLookupFunction
       );
 
     return instruction;
@@ -112,7 +114,7 @@ export class SyntaxInterpreter {
       if(current === ';'){
         info = language.inspectAttribute(resources, name, target.trim());
         language.createAttributeInstruction(resources, element, info, instruction);
-        
+
         if(!instruction.attributes[info.attrName]){
           instruction.attributes[info.attrName] = info.attrValue;
         }
@@ -178,7 +180,7 @@ SyntaxInterpreter.prototype['two-way'] = function(resources, element, info, exis
       info.attrName,
       this.parser.parse(info.attrValue),
       TWO_WAY,
-      resources.valueConverterLookupFunction    
+      resources.valueConverterLookupFunction
     );
 
   return instruction;
@@ -192,7 +194,7 @@ SyntaxInterpreter.prototype['one-way'] = function(resources, element, info, exis
       this.attributeMap[info.attrName] || info.attrName,
       this.parser.parse(info.attrValue),
       ONE_WAY,
-      resources.valueConverterLookupFunction    
+      resources.valueConverterLookupFunction
     );
 
   return instruction;
@@ -206,7 +208,7 @@ SyntaxInterpreter.prototype['one-time'] = function(resources, element, info, exi
       this.attributeMap[info.attrName] || info.attrName,
       this.parser.parse(info.attrValue),
       ONE_TIME,
-      resources.valueConverterLookupFunction    
+      resources.valueConverterLookupFunction
     );
 
   return instruction;

--- a/test/syntax-interpreter.spec.js
+++ b/test/syntax-interpreter.spec.js
@@ -1,0 +1,69 @@
+import {SyntaxInterpreter} from '../src/syntax-interpreter';
+import {
+  Parser,
+  ObserverLocator,
+  EventManager,
+  ListenerExpression,
+  BindingExpression,
+  NameExpression,
+  CallExpression,
+  ONE_WAY,
+  TWO_WAY,
+  ONE_TIME
+} from 'aurelia-binding';
+
+export function createElement(html) {
+  var div = document.createElement('div');
+  div.innerHTML = html;
+  return div.firstChild;
+}
+
+describe('SyntaxInterpreter', () => {
+  describe('determineDefaultBindingMode', () => {
+    var interpreter;
+
+    beforeAll(() => {
+      interpreter = new SyntaxInterpreter(new Parser(), new ObserverLocator(), new EventManager());
+    });
+
+    it('handles input', () => {
+      var el = createElement('<input type="checkbox">');
+      expect(interpreter.determineDefaultBindingMode(el, 'value')).toBe(TWO_WAY);
+      expect(interpreter.determineDefaultBindingMode(el, 'checked')).toBe(TWO_WAY);
+      expect(interpreter.determineDefaultBindingMode(el, 'foo')).toBe(ONE_WAY);
+    });
+
+    it('handles textarea', () => {
+      var el = createElement('<textarea></textarea>');
+      expect(interpreter.determineDefaultBindingMode(el, 'value')).toBe(TWO_WAY);
+      expect(interpreter.determineDefaultBindingMode(el, 'foo')).toBe(ONE_WAY);
+    });
+
+    it('handles textarea', () => {
+      var el = createElement('<select></select>');
+      expect(interpreter.determineDefaultBindingMode(el, 'value')).toBe(TWO_WAY);
+      expect(interpreter.determineDefaultBindingMode(el, 'foo')).toBe(ONE_WAY);
+    });
+
+    it('handles contenteditable="true"', () => {
+      var el = createElement('<div contenteditable="true"></div>');
+      expect(interpreter.determineDefaultBindingMode(el, 'textcontent')).toBe(TWO_WAY);
+      expect(interpreter.determineDefaultBindingMode(el, 'innerhtml')).toBe(TWO_WAY);
+      expect(interpreter.determineDefaultBindingMode(el, 'foo')).toBe(ONE_WAY);
+    });
+
+    it('handles contenteditable="false"', () => {
+      var el = createElement('<div contenteditable="false"></div>');
+      expect(interpreter.determineDefaultBindingMode(el, 'textcontent')).toBe(ONE_WAY);
+      expect(interpreter.determineDefaultBindingMode(el, 'innerhtml')).toBe(ONE_WAY);
+      expect(interpreter.determineDefaultBindingMode(el, 'foo')).toBe(ONE_WAY);
+    });
+
+    it('handles inherited contenteditable', () => {
+      var el = createElement('<div></div>');
+      expect(interpreter.determineDefaultBindingMode(el, 'textcontent')).toBe(ONE_WAY);
+      expect(interpreter.determineDefaultBindingMode(el, 'innerhtml')).toBe(ONE_WAY);
+      expect(interpreter.determineDefaultBindingMode(el, 'foo')).toBe(ONE_WAY);
+    });
+  });
+});


### PR DESCRIPTION
Fixes aurelia/binding#45
