### PR TITLE
fix(attribute-map): add rowspan and colspan attributes

### DIFF
--- a/src/binding-language.js
+++ b/src/binding-language.js
@@ -30,6 +30,8 @@ export class TemplatingBindingLanguage extends BindingLanguage {
       'formmethod':'formMethod',
       'formnovalidate':'formNoValidate',
       'formtarget':'formTarget',
+      'rowspan':'rowSpan',
+      'colspan':'colSpan'
     };
   }
 


### PR DESCRIPTION
Binding to a td rowspan and colspan won't work unless they are
added to the binding-language attribute map.
