### PR TITLE
fix(attributeMap): do not remap style

### DIFF
--- a/src/binding-language.js
+++ b/src/binding-language.js
@@ -16,7 +16,6 @@ export class TemplatingBindingLanguage extends BindingLanguage {
     this.emptyStringExpression = this.parser.parse('\'\'');
     syntaxInterpreter.language = this;
     this.attributeMap = syntaxInterpreter.attributeMap = {
-      'class':'className',
       'contenteditable':'contentEditable',
       'for':'htmlFor',
       'tabindex':'tabIndex',


### PR DESCRIPTION
The new StyleObserver in aurelia-binding handles the style attribute now.
