### PR TITLE
feat(input): Adds default binding mode for input type file

### DIFF
--- a/src/syntax-interpreter.js
+++ b/src/syntax-interpreter.js
@@ -43,7 +43,7 @@ export class SyntaxInterpreter {
     var tagName = element.tagName.toLowerCase();
 
     if(tagName === 'input'){
-      return attrName === 'value' || attrName === 'checked' ? bindingMode.twoWay : bindingMode.oneWay;
+      return attrName === 'value' || attrName === 'checked' || attrName === 'files' ? bindingMode.twoWay : bindingMode.oneWay;
     }else if(tagName == 'textarea' || tagName == 'select'){
       return attrName == 'value' ? bindingMode.twoWay : bindingMode.oneWay;
     }else if(attrName === 'textcontent' || attrName === 'innerhtml'){

--- a/test/syntax-interpreter.spec.js
+++ b/test/syntax-interpreter.spec.js
@@ -29,6 +29,9 @@ describe('SyntaxInterpreter', () => {
       expect(interpreter.determineDefaultBindingMode(el, 'value')).toBe(bindingMode.twoWay);
       expect(interpreter.determineDefaultBindingMode(el, 'checked')).toBe(bindingMode.twoWay);
       expect(interpreter.determineDefaultBindingMode(el, 'foo')).toBe(bindingMode.oneWay);
+
+      var el = createElement('<input type="file">');
+      expect(interpreter.determineDefaultBindingMode(el, 'files')).toBe(bindingMode.twoWay);
     });
 
     it('handles textarea', () => {


### PR DESCRIPTION
Fixes https://github.com/aurelia/binding/issues/130
Related to https://github.com/aurelia/binding/pull/131
Allows changes in the files property of an input type file to notify the view-model property.
