### PR TITLE
feat(syntax-interpreter): allow single quoted strings in options attributes

### DIFF
--- a/src/syntax-interpreter.js
+++ b/src/syntax-interpreter.js
@@ -111,11 +111,13 @@ export class SyntaxInterpreter {
     let current;
     let i;
     let ii;
+    let inString = false;
+    let inEscape = false
 
     for (i = 0, ii = attrValue.length; i < ii; ++i) {
       current = attrValue[i];
 
-      if (current === ';') {
+      if (current === ';' && !inString) {
         info = language.inspectAttribute(resources, name, target.trim());
         language.createAttributeInstruction(resources, element, info, instruction, context);
 
@@ -128,9 +130,19 @@ export class SyntaxInterpreter {
       } else if (current === ':' && name === null) {
         name = target.trim();
         target = '';
+      } else if (current === '\\') {
+        target += current;
+        inEscape = true;
+          continue;
       } else {
         target += current;
+
+        if(name !== null && inEscape === false && current === '\'') {
+          inString = !inString;
+        }
       }
+
+      inEscape = false;
     }
 
     if (name !== null) {

--- a/test/syntax-interpreter.spec.js
+++ b/test/syntax-interpreter.spec.js
@@ -152,6 +152,49 @@ describe('SyntaxInterpreter', () => {
       expect(instruction.attributes.key).toBe('foo');
       expect(instruction.attributes.value).toBe('bar');
     });
+  });
 
+  describe('options attributes', () => {
+    var interpreter, info;
+
+    beforeAll(() => {
+      interpreter = new SyntaxInterpreter(new Parser(), new ObserverLocator(), new EventManager());
+
+      interpreter.language = {
+        inspectAttribute(resources, attrName, attrValue) {
+          return {
+            attrName: attrName,
+            attrValue: attrValue
+          };
+        },
+        createAttributeInstruction() {
+          return;
+        }
+      }
+
+      info = {
+        attrName: 'custom',
+        command: null,
+        defaultBindingMode: 1
+      };
+    });
+
+    it('handles a semicolon inside a string of an options attribute', () => {
+      info.attrValue = "foo: 'bar;';";
+      var instruction = interpreter.options({}, null, info, null);
+      expect(instruction.attributes['foo']).toBe("'bar;'");
+    });
+
+    it('handles an escaped single quote inside a string of an options attribute', () => {
+      info.attrValue = "foo: 'bar\\'';";
+      var instruction = interpreter.options({}, null, info, null);
+      expect(instruction.attributes['foo']).toBe("'bar\\''");
+    });
+
+    it('handles an escaped single quote and a semicolon inside a string of an options attribute', () => {
+      info.attrValue = "foo: 'bar\\';';";
+      var instruction = interpreter.options({}, null, info, null);
+      expect(instruction.attributes['foo']).toBe("'bar\\';'");
+    });
   });
 });


### PR DESCRIPTION
I've added three unit tests, but there will likely need to be more. I used double quotes in the unit tests to attempt to make the test strings more readable.
