### PR TITLE
fix(attribute mapping): textarea maxlength binding

### DIFF
--- a/src/attribute-map.js
+++ b/src/attribute-map.js
@@ -28,6 +28,8 @@ export class AttributeMap {
     this.register('input', 'formnovalidate', 'formNoValidate');
     this.register('input', 'formtarget', 'formTarget');
 
+    this.register('textarea', 'maxlength', 'maxLength');
+
     this.register('td', 'rowspan', 'rowSpan');
     this.register('td', 'colspan', 'colSpan');
     this.register('th', 'rowspan', 'rowSpan');

--- a/test/attribute-map.spec.js
+++ b/test/attribute-map.spec.js
@@ -19,5 +19,7 @@ describe('AttributeMap', () => {
 
     expect(attributeMap.map('svg', 'viewBox')).toBe('viewBox');
     expect(attributeMap.map('svg', 'stroke-width')).toBe('stroke-width');
+
+    expect(attributeMap.map('textarea', 'maxlength')).toBe('maxLength');
   });
 });


### PR DESCRIPTION
allow binding to maxlength attribute on textarea tags

closes #90

![works_on_my_machine](https://cloud.githubusercontent.com/assets/8335112/15995410/fc59a22a-316e-11e6-96dc-050a5bfaf9cd.png)

Not sure if there are other textarea attributes that I should be mapping at the same time, but this one was the attribute affecting me.
