### PR TITLE
perf(AttributeMap): use non-capturing regex group

### DIFF
--- a/src/attribute-map.js
+++ b/src/attribute-map.js
@@ -71,7 +71,7 @@ export class AttributeMap {
       return this.allElements[attributeName];
     }
     // do not camel case data-*, aria-*, or attributes with : in the name.
-    if (/(^data-)|(^aria-)|:/.test(attributeName)) {
+    if (/(?:^data-)|(?:^aria-)|:/.test(attributeName)) {
       return attributeName;
     }
     return camelCase(attributeName);


### PR DESCRIPTION
Hi, from this [Benchmark https://gist.run/?id=b06f276129f58ec3422e8886cddb9af4](https://gist.run/?id=b06f276129f58ec3422e8886cddb9af4)

Changing 
```js
if (/(^data-)|(^aria-)|:/.test(attributeName))
```

to

```js
if (/(?:^data-)|(?:^aria-)|:/.test(attributeName))
```

could improve performance for around 20+%. But I'm not sure if micro opts like this are needed. Please close if not necessary.