### PR TITLE
fix(syntax-interpreter): use the hyphenated name

### DIFF
--- a/src/syntax-interpreter.js
+++ b/src/syntax-interpreter.js
@@ -191,7 +191,7 @@ export class SyntaxInterpreter {
   _getPrimaryPropertyName(resources, context) {
     let type = resources.getAttribute(context.attributeName);
     if (type && type.primaryProperty) {
-      return type.primaryProperty.name;
+      return type.primaryProperty.attribute;
     }
     return null;
   }

--- a/test/syntax-interpreter.spec.js
+++ b/test/syntax-interpreter.spec.js
@@ -273,7 +273,7 @@ describe('SyntaxInterpreter', () => {
       info.attrValue = "bar";
 
       spyOn(resources,'getAttribute').and.returnValue({
-        primaryProperty: { name: 'foo' }
+        primaryProperty: { attribute: 'foo' }
       });
 
       let instruction = interpreter.options(resources, null, info, null, { attributeName: 'foo' });
@@ -286,7 +286,7 @@ describe('SyntaxInterpreter', () => {
       info.attrValue = "bar;";
 
       spyOn(resources,'getAttribute').and.returnValue({
-        primaryProperty: { name: 'foo' }
+        primaryProperty: { attribute: 'foo' }
       });
 
       let instruction = interpreter.options(resources, null, info, null, { attributeName: 'foo' });
@@ -298,10 +298,6 @@ describe('SyntaxInterpreter', () => {
 
       info.attrValue = "foo: bar";
 
-      spyOn(resources,'getAttribute').and.returnValue({
-        primaryProperty: { name: 'foo' }
-      });
-
       let instruction = interpreter.options(resources, null, info, null, { attributeName: 'foo' });
       expect(instruction.attributes['foo']).toBe('bar');
     });
@@ -310,10 +306,6 @@ describe('SyntaxInterpreter', () => {
       let resources = { getAttribute(name) {} };
 
       info.attrValue = "foo: bar;";
-
-      spyOn(resources,'getAttribute').and.returnValue({
-        primaryProperty: { name: 'foo' }
-      });
 
       let instruction = interpreter.options(resources, null, info, null, { attributeName: 'foo' });
       expect(instruction.attributes['foo']).toBe('bar');
@@ -324,10 +316,6 @@ describe('SyntaxInterpreter', () => {
 
       info.attrValue = "far: boo";
 
-      spyOn(resources,'getAttribute').and.returnValue({
-        primaryProperty: { name: 'foo' }
-      });
-
       let instruction = interpreter.options(resources, null, info, null, { attributeName: 'foo' });
       expect(instruction.attributes['far']).toBe('boo');
     });
@@ -336,10 +324,6 @@ describe('SyntaxInterpreter', () => {
       let resources = { getAttribute(name) {} };
 
       info.attrValue = "far: boo;";
-
-      spyOn(resources,'getAttribute').and.returnValue({
-        primaryProperty: { name: 'foo' }
-      });
 
       let instruction = interpreter.options(resources, null, info, null, { attributeName: 'foo' });
       expect(instruction.attributes['far']).toBe('boo');


### PR DESCRIPTION
 of the primary property fix #122
This is similar to aurelia/templating#577 but it covers the usage without a binding command.